### PR TITLE
Make formatting and pretty printing functions more robust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ Authors@R:
     person("Ian", "Powell", , "powell.ian.n@gmail.com", role = c("cre", "aut", "cph"))
 Imports: 
     cli,
+    pillar,
     rlang,
     vctrs (>= 0.6.5)
 RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Suggests:
     dplyr,
     fansi,
     testthat (>= 3.0.0),
-    tidyr
+    tidyr,
+    withr
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 URL: https://github.com/inpowell/maskr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,9 @@
 
 S3method(as.character,maskr_masked)
 S3method(format,maskr_masked)
+S3method(format,pillar_shaft_maskr_masked)
 S3method(obj_print_data,maskr_masked)
+S3method(pillar::pillar_shaft,maskr_masked)
 S3method(vec_arith,maskr_masked)
 S3method(vec_arith.Date,maskr_masked,.vec_arith.atomic.maskr_masked)
 S3method(vec_arith.logical,maskr_masked,.vec_arith.atomic.maskr_masked)

--- a/R/display.R
+++ b/R/display.R
@@ -1,5 +1,4 @@
 #' @export
-#' @importFrom cli ansi_string col_red col_grey
 format.maskr_masked <- function(
     x,
     ...,
@@ -21,11 +20,11 @@ format.maskr_masked <- function(
   }
 
   # Initialise formatted vector
-  fmt <- ansi_string(character(length(x)))
+  fmt <- character(length(x))
 
   # Fill with non-missing, non-suppressed data
   args$x <- vec_slice(data, !mask & !na)
-  vec_slice(fmt, !mask & !na) <- ansi_string(do.call('format', args))
+  vec_slice(fmt, !mask & !na) <- do.call('format', args)
 
   # For masked/missing, need to justify right for numerics
   if (num) args$justify <- 'right'
@@ -37,19 +36,26 @@ format.maskr_masked <- function(
 
   # Fill with missing, non-masked data
   args$x <- 'NA'
-  vec_slice(fmt, !mask & na) <- col_red(do.call('format', args))
+  vec_slice(fmt, !mask & na) <- do.call('format', args)
 
   # Fill with masked data
   args$x <- rep
-  vec_slice(fmt, mask) <- col_grey(do.call('format', args))
+  vec_slice(fmt, mask) <- do.call('format', args)
 
   fmt
 }
 
 #' @export
+#' @importFrom cli ansi_string col_red col_grey
 obj_print_data.maskr_masked <- function(x, ...) {
-  fmt <- format(x, ...)
-  cat(fmt)
+  fmt <- ansi_string(format(x, ...))
+  na <- is.na(unmask(x))
+  masked <- mask(x)
+
+  fmt[na] <- col_red(fmt[na])
+  fmt[masked] <- col_grey(fmt[masked])
+
+  cat(fmt, fill = TRUE)
   invisible(x)
 }
 

--- a/R/display.R
+++ b/R/display.R
@@ -101,6 +101,7 @@ check_replacement <- function(rep) {
 
 #' @exportS3Method pillar::pillar_shaft
 pillar_shaft.maskr_masked <- function(x, ..., rep = getOption('maskr.replacement', 'n.p.')) {
+  check_replacement(rep)
   shft <- pillar::pillar_shaft(unmask(x), ...)
   class(shft) <- c("pillar_shaft_maskr_masked", class(shft))
   attr(shft, 'replacement') <- rep

--- a/R/display.R
+++ b/R/display.R
@@ -98,3 +98,25 @@ check_replacement <- function(rep) {
 
   invisible(rep)
 }
+
+#' @exportS3Method pillar::pillar_shaft
+pillar_shaft.maskr_masked <- function(x, ..., rep = getOption('maskr.replacement', 'n.p.')) {
+  shft <- pillar::pillar_shaft(unmask(x), ...)
+  class(shft) <- c("pillar_shaft_maskr_masked", class(shft))
+  attr(shft, 'replacement') <- rep
+  attr(shft, 'mask') <- mask(x)
+
+  if (any(mask(x))) {
+    attr(shft, 'min_width') <- max(attr(shft, 'min_width'), nchar(rep))
+    attr(shft, 'width') <- max(attr(shft, 'width'), nchar(rep))
+  }
+
+  shft
+}
+
+#' @export
+format.pillar_shaft_maskr_masked <- function(x, width, ...) {
+  orn <- NextMethod('format')
+  orn[attr(x, 'mask')] <- pillar::style_subtle(attr(x, 'replacement'))
+  orn
+}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Other types of atomic vectors can be masked as well:
 ``` r
 masked(letters, letters %in% c('a', 'e', 'i', 'o', 'u'))
 #> <character+masked[26]>
-#> n.p. b    c    d    n.p. f    g    h    n.p. j    k    l    m    n    n.p. p    q    r    s    t    n.p. v    w    x    y    z
+#> n.p. b    c    d    n.p. f    g    h    n.p. j    k    l    m    n    n.p. p    
+#> q    r    s    t    n.p. v    w    x    y    z
 ```
 
 We can also use this to control which data gets displayed in data frames

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ tabular |>
 #> # Groups:   Activity [4]
 #>    Activity Region     Count   Percent
 #>    <fct>    <fct>  <int+msk> <dbl+msk>
-#>  1 I        A             10  25.00000
-#>  2 I        B             25  62.50000
-#>  3 I        C              5  12.50000
-#>  4 I        Total         40 100.00000
+#>  1 I        A             10      25  
+#>  2 I        B             25      62.5
+#>  3 I        C              5      12.5
+#>  4 I        Total         40     100  
 #>  5 II       A           n.p.      n.p.
 #>  6 II       B             13      n.p.
 #>  7 II       C             11      n.p.
@@ -132,10 +132,10 @@ tabular |>
 #> 10 III      B             20      n.p.
 #> 11 III      C             24      n.p.
 #> 12 III      Total       n.p.      n.p.
-#> 13 Total    A             43  30.49645
-#> 14 Total    B             58  41.13475
-#> 15 Total    C             40  28.36879
-#> 16 Total    Total        141 100.00000
+#> 13 Total    A             43      30.5
+#> 14 Total    B             58      41.1
+#> 15 Total    C             40      28.4
+#> 16 Total    Total        141     100
 ```
 
 Notice that where we have divided by a masked cell, the percentage is

--- a/tests/testthat/_snaps/display.md
+++ b/tests/testthat/_snaps/display.md
@@ -22,3 +22,126 @@
       <character+masked[4]>
       n.p. 2    NA   n.p.
 
+# masked vectors have pretty printing in tibbles
+
+    Code
+      print(test_table, width = 100L)
+    Output
+      # A tibble: 6 x 9
+        Logical    ShortInt   Integer    Double BigDouble Factor    Ordered  
+        <lgl+msk> <int+msk> <int+msk> <dbl+msk> <dbl+msk> <fct+msk> <ord+msk>
+      1 FALSE             8      9872      80.1      n.p. A         X        
+      2 TRUE              9     11106      n.p.  9.31e-10 B         Y        
+      3 FALSE            10      n.p.     100.   1   e+ 0 A         Z        
+      4 TRUE           n.p.     13574     110.   1.07e+ 9 B         U        
+      5 n.p.             12     14808     120.   1.15e+18 A         n.p.     
+      6 NA               NA        NA      NA   NA        n.p.      <NA>     
+        Character LongCharacter                                      
+        <chr+msk> <chr+msk>                                          
+      1 ABCDE     A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      2 BCDEF     A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      3 CDEFGHI   n.p.                                               
+      4 n.p.      A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      5 EFGHIJKL  A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      6 <NA>      <NA>                                               
+
+---
+
+    Code
+      print(test_table, width = 90L)
+    Output
+      # A tibble: 6 x 9
+        Logical    ShortInt   Integer    Double BigDouble Factor    Ordered  
+        <lgl+msk> <int+msk> <int+msk> <dbl+msk> <dbl+msk> <fct+msk> <ord+msk>
+      1 FALSE             8      9872      80.1      n.p. A         X        
+      2 TRUE              9     11106      n.p.  9.31e-10 B         Y        
+      3 FALSE            10      n.p.     100.   1   e+ 0 A         Z        
+      4 TRUE           n.p.     13574     110.   1.07e+ 9 B         U        
+      5 n.p.             12     14808     120.   1.15e+18 A         n.p.     
+      6 NA               NA        NA      NA   NA        n.p.      <NA>     
+        Character LongCharacter                                      
+        <chr+msk> <chr+msk>                                          
+      1 ABCDE     A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      2 BCDEF     A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      3 CDEFGHI   n.p.                                               
+      4 n.p.      A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      5 EFGHIJKL  A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      6 <NA>      <NA>                                               
+
+---
+
+    Code
+      print(test_table, width = 80L)
+    Output
+      # A tibble: 6 x 9
+        Logical    ShortInt   Integer    Double BigDouble Factor    Ordered  Character
+        <lgl+msk> <int+msk> <int+msk> <dbl+msk> <dbl+msk> <fct+msk> <ord+ms> <chr+msk>
+      1 FALSE             8      9872      80.1      n.p. A         X        ABCDE    
+      2 TRUE              9     11106      n.p.  9.31e-10 B         Y        BCDEF    
+      3 FALSE            10      n.p.     100.   1   e+ 0 A         Z        CDEFGHI  
+      4 TRUE           n.p.     13574     110.   1.07e+ 9 B         U        n.p.     
+      5 n.p.             12     14808     120.   1.15e+18 A         n.p.     EFGHIJKL 
+      6 NA               NA        NA      NA   NA        n.p.      <NA>     <NA>     
+      # i 1 more variable: LongCharacter <chr+msk>
+
+---
+
+    Code
+      print(test_table, width = 60L)
+    Output
+      # A tibble: 6 x 9
+        Logical   ShortInt Integer Double BigDouble Factor Ordered
+        <lgl+msk> <int+ms> <int+m> <dbl+> <dbl+msk> <fct+> <ord+m>
+      1 FALSE            8    9872   80.1      n.p. A      X      
+      2 TRUE             9   11106   n.p.  9.31e-10 B      Y      
+      3 FALSE           10    n.p.  100.   1   e+ 0 A      Z      
+      4 TRUE          n.p.   13574  110.   1.07e+ 9 B      U      
+      5 n.p.            12   14808  120.   1.15e+18 A      n.p.   
+      6 NA              NA      NA   NA   NA        n.p.   <NA>   
+      # i 2 more variables: Character <chr+msk>,
+      #   LongCharacter <chr+msk>
+
+---
+
+    Code
+      print(test_table, width = 40L)
+    Output
+      # A tibble: 6 x 9
+        Logical    ShortInt   Integer   Double
+        <lgl+msk> <int+msk> <int+msk> <dbl+ms>
+      1 FALSE             8      9872     80.1
+      2 TRUE              9     11106     n.p.
+      3 FALSE            10      n.p.    100. 
+      4 TRUE           n.p.     13574    110. 
+      5 n.p.             12     14808    120. 
+      6 NA               NA        NA     NA  
+      # i 5 more variables:
+      #   BigDouble <dbl+msk>,
+      #   Factor <fct+msk>,
+      #   Ordered <ord+msk>,
+      #   Character <chr+msk>,
+      #   LongCharacter <chr+msk>
+
+---
+
+    Code
+      print(test_table, width = 100L)
+    Output
+      # A tibble: 6 x 9
+        Logical    ShortInt   Integer    Double BigDouble Factor    Ordered  
+        <lgl+msk> <int+msk> <int+msk> <dbl+msk> <dbl+msk> <fct+msk> <ord+msk>
+      1 FALSE             8      9872      80.1         * A         X        
+      2 TRUE              9     11106         *  9.31e-10 B         Y        
+      3 FALSE            10         *     100.   1   e+ 0 A         Z        
+      4 TRUE              *     13574     110.   1.07e+ 9 B         U        
+      5 *                12     14808     120.   1.15e+18 A         *        
+      6 NA               NA        NA      NA   NA        *         <NA>     
+        Character LongCharacter                                      
+        <chr+msk> <chr+msk>                                          
+      1 ABCDE     A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      2 BCDEF     A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      3 CDEFGHI   *                                                  
+      4 *         A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      5 EFGHIJKL  A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+      6 <NA>      <NA>                                               
+

--- a/tests/testthat/test-display.R
+++ b/tests/testthat/test-display.R
@@ -34,7 +34,9 @@ test_that("replacements must be length-1 character vectors", {
   msk <- masked(c('abcde', 'defgh'), c(FALSE, TRUE))
   expect_error(format(msk, rep = c('a', 'b')), class = 'maskr_error_rep_length')
   expect_error(as.character(msk, rep = c('a', 'b')), class = 'maskr_error_rep_length')
+  expect_error(pillar::pillar_shaft(msk, rep = c('a', 'b')), class = 'maskr_error_rep_length')
 
   expect_error(format(msk, rep = 1L), class = 'maskr_error_rep_type')
   expect_error(as.character(msk, rep = FALSE), class = 'maskr_error_rep_type')
+  expect_error(pillar::pillar_shaft(msk, rep = charToRaw('*')), class = 'maskr_error_rep_type')
 })


### PR DESCRIPTION
This PR introduces some formatting changes for masked objects:

- `format()` now returns a character vector _without_ ANSI control codes for colouring. This improves behaviour in, for example, R Markdown documents with `df_print: paged` or similar.
- To ensure pretty printing is available on the console, ANSI escape codes are added in the print stage for masked objects.
- printing in tibbles is made more robust by originally dispatching `pillar_shaft()` to the underlying data, and then masking formatted values after the fact. This is a little hacky, and means `NA` and `n.p.` (or whichever replacement value is used after the fact) do not necessarily align. 